### PR TITLE
feat: Add file handling + Typhoon OCR integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,10 @@ ANTHROPIC_API_KEY=sk-ant-...
 DEEPSEEK_API_KEY=sk-...
 GOOGLE_API_KEY=AIza...
 
+# Typhoon OCR (Thai OCR - free 20 req/min)
+# Get API key: https://playground.opentyphoon.ai/api-key
+TYPHOON_OCR_API_KEY=your-typhoon-api-key
+
 # OpenCode Settings
 OPENCODE_URL=http://opencode:4096
 OPENCODE_PASSWORD=your_password

--- a/src/index.ts
+++ b/src/index.ts
@@ -243,6 +243,149 @@ async function handleImageMessage(
   }).catch(() => {})
 }
 
+// --- Handle incoming LINE File message ---
+async function handleFileMessage(
+  userId: string,
+  messageId: string,
+  fileName: string,
+  fileSize: number,
+  replyToken: string,
+  sessionKey: string | null = userId,
+  isGroup: boolean = false,
+): Promise<void> {
+  const userName = userProfiles.get(userId)?.displayName || userId.slice(-8)
+  log(`📎 File from ${userName}: ${fileName} (${fileSize} bytes), group: ${isGroup}, key: ${sessionKey?.slice(-8)}`)
+
+  // Only handle text files
+  const textExtensions = ['.txt', '.csv', '.json', '.js', '.ts', '.py', '.md', '.log']
+  const isTextFile = textExtensions.some(ext => fileName.toLowerCase().endsWith(ext))
+  
+  if (!isTextFile) {
+    if (!isGroup) {
+      await lineClient.replyMessage({
+        replyToken,
+        messages: [{ type: "text", text: `รองรับเฉพาะไฟล์ข้อความ (.txt, .csv, .json, .js, .ts, .py, .md, .log) ครับ` }],
+      })
+    }
+    return
+  }
+
+  // Download file from LINE
+  let fileContent: ArrayBuffer
+  try {
+    const blob = await lineBlobClient.getMessageContent(messageId)
+    fileContent = await blob.arrayBuffer()
+  } catch (err: any) {
+    log(`❌ Failed to download file: ${err?.message}`)
+    if (!isGroup) {
+      await lineClient.replyMessage({
+        replyToken,
+        messages: [{ type: "text", text: `ดาวน์โหลดไฟล์ไม่สำเร็จครับ` }],
+      })
+    }
+    return
+  }
+
+  // Ensure temp directory exists for this session
+  const tempDir = `/workspace/temp/${sessionKey}`
+  try {
+    await Bun.write(`${tempDir}/.gitkeep`, '')
+  } catch {}
+
+  // Save file to temp with unique name
+  const safeFileName = fileName.replace(/[^a-zA-Z0-9._-]/g, '_')
+  const timestamp = Date.now()
+  const filePath = `${tempDir}/${timestamp}_${safeFileName}`
+  
+  try {
+    await Bun.write(filePath, fileContent)
+    log(`💾 Saved file to ${filePath}`)
+  } catch (err: any) {
+    log(`❌ Failed to save file: ${err?.message}`)
+    if (!isGroup) {
+      await lineClient.replyMessage({
+        replyToken,
+        messages: [{ type: "text", text: `บันทึกไฟล์ไม่สำเร็จครับ` }],
+      })
+    }
+    return
+  }
+
+  // Read file content
+  let content: string
+  try {
+    content = await Bun.file(filePath).text()
+    log(`📖 Read ${content.length} chars from ${fileName}`)
+  } catch (err: any) {
+    log(`❌ Failed to read file: ${err?.message}`)
+    if (!isGroup) {
+      await lineClient.replyMessage({
+        replyToken,
+        messages: [{ type: "text", text: `อ่านไฟล์ไม่สำเร็จครับ` }],
+      })
+    }
+    return
+  }
+
+  // Send acknowledgment
+  if (!isGroup) {
+    await lineClient.replyMessage({
+      replyToken,
+      messages: [{ type: "text", text: `📎 รับไฟล์ ${fileName} แล้วครับ (${content.length} ตัวอักษร)\n\nกำลังวิเคราะห์...` }],
+    })
+  }
+
+  // Get or create OpenCode session
+  let session = sessionKey ? sessions.get(sessionKey) : null
+
+  if (!session) {
+    console.log("Creating new OpenCode session for file...")
+    try {
+      const result = await createSession(`LINE: ${userId.slice(-8)}${isGroup ? " (group)" : ""}`)
+      session = { sessionId: result.id, userId, isGroup, timeoutCount: 0 }
+      if (sessionKey) sessions.set(sessionKey, session)
+    } catch (err: any) {
+      console.error("Failed to create session:", err?.message)
+      if (!isGroup) {
+        await sendMessage(sessionKey || userId, "สร้าง session ไม่สำเร็จครับ ลองส่งไฟล์ใหม่อีกครั้ง", replyToken)
+      }
+      return
+    }
+  }
+
+  // Resolve model for this session
+  const modelKey = sessionKey ? (modelPrefs.get(sessionKey) ?? DEFAULT_MODEL) : DEFAULT_MODEL
+  const model = MODELS[modelKey]
+
+  // Send file content to AI
+  const prompt = `📎 ไฟล์: ${fileName}\n\n${content}`
+  log(`➡️ Sending file content to OpenCode: ${fileName} (${content.length} chars)`)
+
+  try {
+    await getUserProfile(userId)
+    const result = await sendPrompt(session.sessionId, prompt, isGroup, userId, undefined, model)
+    const responseText = extractResponse(result)
+
+    // Handle timeout
+    if (result?._timedOut || result?._truncated) {
+      session.timeoutCount = (session.timeoutCount || 0) + 1
+      if (session.timeoutCount >= 3) {
+        responseText += '\n\n⚠️ Timeout ติดต่อกัน 3 ครั้ง — session อาจค้างอยู่\nแนะนำ: พิมพ์ /new แล้วส่งไฟล์ใหม่'
+      }
+    } else {
+      session.timeoutCount = 0
+    }
+
+    log(`⬅️ Response (${responseText.length} chars): ${responseText.slice(0, 100)}...`)
+    await sendMessage(sessionKey || userId, responseText, replyToken)
+  } catch (err: any) {
+    log(`❌ OpenCode prompt error: ${err?.message}`)
+    if (!isGroup) {
+      await sendMessage(sessionKey || userId, `วิเคราะห์ไฟล์ไม่สำเร็จ: ${err?.message?.slice(0, 200)}`, replyToken)
+    }
+  }
+}
+
 // --- Wait for OpenCode server ---
 async function waitForOpenCode(maxRetries = 30, delayMs = 2000): Promise<boolean> {
   for (let i = 0; i < maxRetries; i++) {
@@ -678,6 +821,10 @@ https://jibjib-meditation.pages.dev
   /sessions — ดูสถานะ session
   /model — ดู/เปลี่ยน AI model
 
+📎 ไฟล์
+  ส่งไฟล์ .txt, .csv, .json, .js, .ts, .py, .md, .log
+  Bot จะอ่านและวิเคราะห์ให้ครับ (ไฟล์แยกตามห้อง ไม่ปนกัน)
+
 🧪 Playground
   /playground — เริ่มต้นสร้าง playground
 
@@ -1000,6 +1147,28 @@ Bun.serve({
             isGroup,
           ).catch((err) => {
             console.error("Error handling image message:", err)
+          })
+        }
+
+        // Handle file messages (including group)
+        if (
+          event.type === "message" &&
+          event.message?.type === "file" &&
+          event.source?.userId
+        ) {
+          const isGroup = !!event.source?.groupId || !!event.source?.roomId
+          const sessionKey = getSessionKey(event)
+
+          handleFileMessage(
+            event.source.userId,
+            event.message.id,
+            event.message.fileName,
+            event.message.fileSize,
+            event.replyToken,
+            sessionKey,
+            isGroup,
+          ).catch((err) => {
+            console.error("Error handling file message:", err)
           })
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,10 @@ const opencodePassword = process.env.OPENCODE_PASSWORD ?? ""
 const opencodeDir = process.env.OPENCODE_DIR ?? "/workspace"
 const lineOAUrl = process.env.LINE_OA_URL ?? "https://line.me/ti/p/~your-oa"
 
+// --- Typhoon OCR Config ---
+const typhoonApiKey = process.env.TYPHOON_OCR_API_KEY ?? ""
+const typhoonApiUrl = "https://api.opentyphoon.ai/v1/chat/completions"
+
 // --- Model config ---
 const MODELS: Record<string, { providerID: string; modelID: string; label: string }> = {
   "pickle":    { providerID: "opencode",  modelID: "big-pickle",                label: "Big Pickle (Free)" },
@@ -223,7 +227,55 @@ function extractResponse(result: any): string {
   return "เสร็จแล้วครับ (ไม่มีข้อความตอบกลับ)"
 }
 
-// --- Handle incoming LINE Image message ---
+// --- Typhoon OCR API ---
+async function callTyphoonOCR(imageBuffer: ArrayBuffer): Promise<string> {
+  if (!typhoonApiKey) {
+    throw new Error("Missing TYPHOON_OCR_API_KEY")
+  }
+
+  // Convert ArrayBuffer to base64
+  const base64Image = Buffer.from(imageBuffer).toString('base64')
+  
+  const response = await fetch(typhoonApiUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${typhoonApiKey}`,
+    },
+    body: JSON.stringify({
+      model: 'typhoon-ocr',
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image_url',
+              image_url: {
+                url: `data:image/jpeg;base64,${base64Image}`,
+              },
+            },
+            {
+              type: 'text',
+              text: 'Please extract all text from this image. Output only the text content in Markdown format.',
+            },
+          ],
+        },
+      ],
+      max_tokens: 4096,
+    }),
+    signal: AbortSignal.timeout(60_000),
+  })
+
+  if (!response.ok) {
+    const errorText = await response.text()
+    throw new Error(`Typhoon OCR API ${response.status}: ${errorText.slice(0, 300)}`)
+  }
+
+  const data = await response.json()
+  return data.choices?.[0]?.message?.content || ''
+}
+
+// --- Handle incoming LINE Image message with OCR ---
 async function handleImageMessage(
   userId: string,
   messageId: string,
@@ -232,15 +284,56 @@ async function handleImageMessage(
   isGroup: boolean = false,
 ): Promise<void> {
   const userName = userProfiles.get(userId)?.displayName || userId.slice(-8)
-  log(`📷 Image from ${userName}, group: ${isGroup}, key: ${sessionKey?.slice(-8)} (no vision)`)
+  log(`📷 Image from ${userName}, group: ${isGroup}, key: ${sessionKey?.slice(-8)}`)
 
-  // Model has no vision — silent in group, short reply in 1:1
+  // Silent in group chat
   if (isGroup) return
 
+  // Show loading
   await lineClient.replyMessage({
     replyToken,
-    messages: [{ type: "text", text: "ยังดูรูปไม่ได้ครับ ส่งเป็นข้อความแทนนะ" }],
+    messages: [{ type: "text", text: "📷 กำลังอ่านรูปด้วย OCR...\n(อาจใช้เวลา 2-5 วินาที)" }],
   }).catch(() => {})
+
+  // Download image from LINE
+  let imageContent: ArrayBuffer
+  try {
+    const blob = await lineBlobClient.getMessageContent(messageId)
+    imageContent = await blob.arrayBuffer()
+  } catch (err: any) {
+    log(`❌ Failed to download image: ${err?.message}`)
+    await sendMessage(sessionKey || userId, "ดาวน์โหลดรูปไม่สำเร็จครับ", replyToken)
+    return
+  }
+
+  // Call Typhoon OCR
+  try {
+    const ocrText = await callTyphoonOCR(imageContent)
+    log(`📖 OCR result (${ocrText.length} chars)`)
+
+    if (!ocrText.trim()) {
+      await sendMessage(sessionKey || userId, "ไม่พบข้อความในรูปครับ", replyToken)
+      return
+    }
+
+    // Save OCR result to temp folder
+    const tempDir = `/workspace/temp/${sessionKey}`
+    try {
+      await Bun.write(`${tempDir}/.gitkeep`, '')
+    } catch {}
+
+    const timestamp = Date.now()
+    const filePath = `${tempDir}/${timestamp}_ocr_result.md`
+    await Bun.write(filePath, ocrText)
+    log(`💾 Saved OCR result to ${filePath}`)
+
+    // Send OCR result to user
+    const response = `📋 ผลการอ่านรูป (OCR):\n\n${ocrText}\n\n---\n💾 บันทึกที่: \`${filePath}\``
+    await sendMessage(sessionKey || userId, response, replyToken)
+  } catch (err: any) {
+    log(`❌ OCR error: ${err?.message}`)
+    await sendMessage(sessionKey || userId, `OCR ไม่สำเร็จ: ${err?.message?.slice(0, 200)}`, replyToken)
+  }
 }
 
 // --- Handle incoming LINE File message ---
@@ -824,6 +917,11 @@ https://jibjib-meditation.pages.dev
 📎 ไฟล์
   ส่งไฟล์ .txt, .csv, .json, .js, .ts, .py, .md, .log
   Bot จะอ่านและวิเคราะห์ให้ครับ (ไฟล์แยกตามห้อง ไม่ปนกัน)
+
+📷 OCR (อ่านข้อความในรูป)
+  ส่งรูปภาพ → Bot จะอ่านข้อความด้วย Typhoon OCR
+  รองรับภาษาไทยแม่นยำมาก (ฟรี 20 requests/min)
+  ผลลัพธ์บันทึกที่ /workspace/temp/{sessionKey}/
 
 🧪 Playground
   /playground — เริ่มต้นสร้าง playground


### PR DESCRIPTION
## Summary
เพิ่มฟีเจอร์รองรับการส่งไฟล์และ OCR รูปภาพใน LINE Bot

## Changes

### 1. File Handling ✅
- ✅ Handle file messages (.txt, .csv, .json, .js, .ts, .py, .md, .log)
- ✅ Save files to `/workspace/temp/{sessionKey}/` ด้วย unique timestamp
- ✅ Session key = userId (1:1) หรือ groupId (group chat)
- ✅ ไฟล์จากแต่ละห้องแยกกัน 100% ไม่ปนกัน
- ✅ อ่านเนื้อหาไฟล์และส่งให้ AI วิเคราะห์
- ✅ อัปเดต /help command พร้อมข้อมูลฟีเจอร์ใหม่

### 2. Typhoon OCR (อ่านข้อความในรูป) ✅
- ✅ ใช้ Typhoon OCR API (คนไทยพัฒนา - แม่นยำภาษาไทยที่สุด)
- ✅ ส่งรูปภาพ → Bot อ่านข้อความด้วย OCR
- ✅ รองรับภาษาไทย + อังกฤษ
- ✅ บันทึกผลลัพธ์ที่ `/workspace/temp/{sessionKey}/{timestamp}_ocr_result.md`
- ✅ ฟรี tier: 20 requests/minute (1,200/hr)
- ✅ อัปเดต /help command

## File Structure
```
/workspace/temp/
├── U1234567890abcdef/      # 1:1 chat (userId)
│   ├── 1709012345_report.txt
│   ├── 1709012346_data.csv
│   └── 1709012347_ocr_result.md
├── C9876543210fedcba/      # Group chat (groupId)
│   ├── 1709012348_notes.md
│   └── 1709012349_code.py
```

## Environment Variables
เพิ่ม `TYPHOON_OCR_API_KEY` ใน `.env`:
```bash
# Get API key: https://playground.opentyphoon.ai/api-key
TYPHOON_OCR_API_KEY=your-typhoon-api-key
```

## Testing
- [ ] ส่งไฟล์ .txt/.csv/.json ใน 1:1 chat
- [ ] ส่งไฟล์ในกลุ่ม (ทุกคนในกลุ่มเห็นไฟล์เดียวกัน)
- [ ] ส่งรูปภาพ → ตรวจสอบ OCR อ่านภาษาไทยได้ถูกต้อง
- [ ] ไฟล์จากคนละห้องไม่ทับกัน

## Related Issue
Closes #7 (รองรับ Image OCR/Analysis)